### PR TITLE
Rename joint_states topic and guarantee proper encoder readings

### DIFF
--- a/gremsy_sdk/src/gimbal_interface.cpp
+++ b/gremsy_sdk/src/gimbal_interface.cpp
@@ -1250,23 +1250,14 @@ uint32_t Gimbal_Interface::get_gimbal_attitude_flag(void)
  * @ret: Gimbal encoder
  */
 attitude<int16_t> Gimbal_Interface::get_gimbal_encoder(void)
-{
+{ 
     pthread_mutex_lock(&_messages.mutex);
-    uint64_t timestamps = _messages.timestamps.mount_status;
+    /* Reset timestamps */
+    _messages.timestamps.mount_status = 0;
+    const mavlink_mount_status_t &mount = _messages.mount_status;
+    attitude<int16_t> encoder(mount.pointing_b, mount.pointing_a, mount.pointing_c);
     pthread_mutex_unlock(&_messages.mutex);
-
-    /* Check gimbal encoder value has changed*/
-    if (timestamps) {
-        pthread_mutex_lock(&_messages.mutex);
-        /* Reset timestamps */
-        _messages.timestamps.mount_status = 0;
-        const mavlink_mount_status_t &mount = _messages.mount_status;
-        attitude<int16_t> encoder(mount.pointing_b, mount.pointing_a, mount.pointing_c);
-        pthread_mutex_unlock(&_messages.mutex);
-        return encoder;
-    }
-
-    return attitude<int16_t>();
+    return encoder;
 }
 
 /**

--- a/gremsy_wrapper/src/gremsy_wrapper.cpp
+++ b/gremsy_wrapper/src/gremsy_wrapper.cpp
@@ -82,7 +82,7 @@ public:
     this->imu_pub_ = this->create_publisher<sensor_msgs::msg::Imu>("~/imu_raw", 1);
     this->gimbal_rotation_pub_ =
       this->create_publisher<geometry_msgs::msg::Vector3Stamped>("~/rotation", 1);
-    this->joint_state_pub_ = this->create_publisher<sensor_msgs::msg::JointState>("~/joint_states",
+    this->joint_state_pub_ = this->create_publisher<sensor_msgs::msg::JointState>("/joint_states",
         1);
 
     // Subscriptions

--- a/gremsy_wrapper/src/gremsy_wrapper.cpp
+++ b/gremsy_wrapper/src/gremsy_wrapper.cpp
@@ -82,7 +82,7 @@ public:
     this->imu_pub_ = this->create_publisher<sensor_msgs::msg::Imu>("~/imu_raw", 1);
     this->gimbal_rotation_pub_ =
       this->create_publisher<geometry_msgs::msg::Vector3Stamped>("~/rotation", 1);
-    this->joint_state_pub_ = this->create_publisher<sensor_msgs::msg::JointState>("/joint_states",
+    this->joint_state_pub_ = this->create_publisher<sensor_msgs::msg::JointState>("joint_states",
         1);
 
     // Subscriptions


### PR DESCRIPTION
Joint states topic has been renamed and gimbal interface now guarantees to send latest encoder readings instead of zeros at times. This version of the code ran of latest rover tests.